### PR TITLE
Add instrumentation to the service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM --platform=linux/x86_64 eclipse-temurin:17-jre-alpine
 
 ENV APP_BASE="/home" \
     APP_NAME="cat-fact-service" \
+    OTEL_ATTRIBUTES="github.repository=https://github.com/ForkingGeniuses/cat-fact-service" \
     SERVER_PORT="8080"
 
 EXPOSE ${SERVER_PORT}
@@ -10,7 +11,12 @@ RUN apk update && apk upgrade && apk add curl openssl gcompat bash busybox-extra
 
 RUN mkdir -p ${APP_BASE}/${APP_NAME}
 
-COPY build/libs/${APP_NAME}*.jar ${APP_BASE}/${APP_NAME}.jar
+# Otel agent
+COPY "/build/output/libs" "${APP_BASE}/${APP_NAME}"
+
+COPY "/build/libs/${APP_NAME}*.jar" "${APP_BASE}/${APP_NAME}.jar"
 
 CMD java $JAVA_OPTS \
+    -Dotel.resource.attributes="${OTEL_ATTRIBUTES}" \
+    -javaagent:${APP_BASE}/${APP_NAME}/honeycomb-opentelemetry-javaagent.jar \
     -jar ${APP_BASE}/${APP_NAME}.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,10 @@ services:
       - DB_NAME=facts
       - DB_USER=postgres
       - DB_PASSWORD=secret
+      - HONEYCOMB_API_KEY=${HONEYCOMB_API_KEY}
+      - SERVICE_NAME=cat-fact-service
+      - HONEYCOMB_API_ENDPOINT=https://api.honeycomb.io:443
+      - OTEL_JAVAAGENT_DEBUG=false
 
   postgres:
     container_name: cat-fact-service-postgres

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
 
+catFactClient = "0.2.0"
 coroutines = "1.7.3"
+honeycomb = "1.5.2"
 jacoco = "0.8.7"
 jooq = "0.9.15"
 jooq_docker_plugin = "0.3.9"


### PR DESCRIPTION
# Purpose

This PR adds instrumentation to the service for better observability.

This change allows to run the code with the Otel agent attached in 2 different modes:

- via Gradle, running the `./gradlew bootRun` command
- via docker-compose running the `docker compose up` command.

To make sure that the service reports to Honeycomb, you need to provide the following environment variable:

```sh
$ export HONEYCOMB_API_KEY=YOUR API KEY
$ docker compose up
```

The information would be available in Honeycomb under the service's dataset:

<img width="1070" alt="image" src="https://github.com/ForkingGeniuses/cat-fact-service/assets/14914865/ca61487e-6792-42ae-a22a-c2eaca9302c1">


# Types of changes

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

# Checklist

- [x] Documentation is updated
- [x] No new tests are needed
